### PR TITLE
Make CFLAGS and LDFLAGS tunable by env variables.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 include commands.mk
 
 OPTS    := -O3
-CFLAGS  := -std=c99 $(OPTS) -fPIC -Wall
-LDFLAGS := -lgawen
+CFLAGS  += -std=c99 $(OPTS) -fPIC -Wall
+LDFLAGS += -lgawen
 
 SRC  = $(wildcard *.c)
 OBJ  = $(foreach obj, $(SRC:.c=.o), $(notdir $(obj)))


### PR DESCRIPTION
CFLAGS and LDFLAGS where assigned, preventing the user to build with custom CFLAGS and LDFLAGS.